### PR TITLE
reactor: modify `juju` fixture for better extension to multi-model tests

### DIFF
--- a/pytest_jubilant/main.py
+++ b/pytest_jubilant/main.py
@@ -5,10 +5,12 @@
 """Main plugin module."""
 import dataclasses
 import logging
+import secrets
 import shlex
 import subprocess
 from pathlib import Path
 from typing import Union, Optional, Dict
+from urllib import request
 
 import yaml
 import pytest
@@ -79,23 +81,53 @@ def pytest_collection_modifyitems(config:pytest.Config, items):
                 item.add_marker(skipper)
 
 
+@dataclasses.dataclass(frozen=True)
+class ModelConfiguration:
+    name: str
+    keep_models: bool
+
+
 @pytest.fixture(scope="module")
-def juju(request):
-    switch = request.config.getoption("--switch")
-    def _maybe_switch(juju):
-        if switch:
-            juju.cli("switch", model, include_model=False)
-        return juju
+def root_model_configuration(request) -> ModelConfiguration:
+    keep_models=request.config.getoption("--keep-models")
 
-    if model := request.config.getoption("--model"):
-        juju = jubilant.Juju(model=model)
-        yield _maybe_switch(juju)
-
+    if name := request.config.getoption("--model"):
+        keep_models=True
     else:
-        with jubilant.temp_model(
-            keep=request.config.getoption("--keep-models")
-        ) as juju:
-            yield _maybe_switch(juju)
+        name = f"{request.module.__name__.rpartition(".")[-1]}+{secrets.token_hex(4)}"
+
+    return ModelConfiguration(
+        name=name,
+        keep_models=keep_models
+    )
+
+
+def juju_client_with_model(model: str, keep_model=False, switch=False) -> jubilant.Juju:
+    juju = jubilant.Juju()
+
+    if not keep_model:
+        juju.add_model(model)
+    else:
+        juju.model = model
+
+    if switch:
+        juju.cli("switch", model, include_model=False)
+
+    return juju
+
+
+@pytest.fixture(scope="module")
+def juju(request, root_model_configuration):
+    juju = juju_client_with_model(
+        model=root_model_configuration.name,
+        keep_model=root_model_configuration.keep_models,
+        switch=request.config.getoption("--switch")
+    )
+    try:
+        yield juju
+    finally:
+        if not root_model_configuration.keep_models:
+            juju.destroy_model(root_model_configuration.name, destroy_storage=True, force=True)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This refactors the `juju` fixture to make it easier for someone to extend its use to multi-model tests.  The goal is to achieve an easy way to manage additional juju models via fixtures or in a pattern that feels native to pytest and doesn't involve a lot of duplication by the user.

Key changes are:
* `root_model_configuration` fixture parses model settings and, if required, generates a random root model name.  This enables the root model name to be used across all tests, even if a specific `juju` fixture is not
* pulls as much logic as possible from `juju` into a reusable function so people can create additional models easily

For single-model tests, this PR should not affect anything.  But for multi-model usage, someone can now in their test file do:

```python
# Define a fixture for any additional model
@pytest.fixture(scope="module")
def another_juju(request, root_model_configuration):
    juju = juju_client_with_model(
        model=f"{root_model_configuration.name}-another",
        keep_model=root_model_configuration.keep_models,
    )
    try:
        yield juju
    finally:
        if not root_model_configuration.keep_models:
            juju.destroy_model(root_model_configuration.name, destroy_storage=True, force=True)


def test_deploy_to_root_model(juju):
  juju.deploy(something)


def test_deploy_to_another_model(another_juju):
  another_juju.deploy(something_else)


def test_integrate_across_models(juju, another_juju):
  juju.offer(something)
  # if we're pedantic here, jubilant doesn't actually have a `consume`?  But you get the idea
  another_juju.consume(offered_thing)
  another_juju.integrate(something_else, offered_thing)
```