### PR TITLE
fix: packing fails if there are no resources

### DIFF
--- a/pytest_jubilant/main.py
+++ b/pytest_jubilant/main.py
@@ -197,11 +197,17 @@ def pack_charm(root: Union[Path, str] = "./") -> _Result:
         if (meta_yaml := Path(root) / meta_name).exists():
             logging.debug(f"found metadata file: {meta_yaml}")
             meta = yaml.safe_load(meta_yaml.read_text())
-            if meta["resources"]:
-                resources = {
-                    resource: res_meta["upstream-source"]
-                    for resource, res_meta in meta["resources"].items()
-                }
+            if meta_resources := meta["resources"]:
+                try:
+                    resources = {
+                        resource: res_meta["upstream-source"]
+                        for resource, res_meta in meta_resources.items()
+                    }
+                except KeyError:
+                    logging.exception(
+                        "The `upstream-source` key wasn't found in the resource. If your charm follows a different convention of pointing at an OCI image, you need to pack it manually."
+                    )
+                    raise
             else:
                 resources = None
                 logging.info(


### PR DESCRIPTION
`parca-scrape-target-operator` doesn't have a resources section in its charmcraft.yaml because it has no resources:

https://github.com/canonical/parca-scrape-target-operator/blob/main/charmcraft.yaml

Because of that, packing it fails with

```
Traceback (most recent call last):
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/runner.py", line 341, in from_call
    result: TResult | None = func()
                             ^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/runner.py", line 242, in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 90, in pytest_runtest_setup
    yield from unraisable_exception_runtest_hook()
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 70, in unraisable_exception_runtest_hook
    yield
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/logging.py", line 840, in pytest_runtest_setup
    yield from self._runtest_for(item, "setup")
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/logging.py", line 829, in _runtest_for
    yield
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/capture.py", line 893, in pytest_runtest_setup
    return (yield)
            ^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/threadexception.py", line 87, in pytest_runtest_setup
    yield from thread_exception_runtest_hook()
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/threadexception.py", line 68, in thread_exception_runtest_hook
    yield
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/runner.py", line 160, in pytest_runtest_setup
    item.session._setupstate.setup(item)
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/runner.py", line 514, in setup
    col.setup()
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/python.py", line 1630, in setup
    self._request._fillfixtures()
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/fixtures.py", line 697, in _fillfixtures
    item.funcargs[argname] = self.getfixturevalue(argname)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/fixtures.py", line 532, in getfixturevalue
    fixturedef = self._get_active_fixturedef(argname)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/fixtures.py", line 617, in _get_active_fixturedef
    fixturedef.execute(request=subrequest)
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/fixtures.py", line 1091, in execute
    result = ihook.pytest_fixture_setup(fixturedef=self, request=request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 182, in _multicall
    return outcome.get_result()
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/setuponly.py", line 36, in pytest_fixture_setup
    return (yield)
            ^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/fixtures.py", line 1140, in pytest_fixture_setup
    result = call_fixture_func(fixturefunc, request, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/_pytest/fixtures.py", line 898, in call_fixture_func
    fixture_result = fixturefunc(**kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/code/parca-scrape-target-operator/tests/integration/conftest.py", line 24, in scrape_target_charm
    pth = pack_charm().charm.absolute()
          ^^^^^^^^^^^^
  File "/home/ubuntu/.cache/uv/builds-v0/.tmp29spiH/lib/python3.12/site-packages/pytest_jubilant/main.py", line 202, in pack_charm
    for resource, res_meta in meta["resources"].items()
                              ~~~~^^^^^^^^^^^^^
KeyError: 'resources'
```