### PR TITLE
fix: proper walrus

### DIFF
--- a/pytest_jubilant/main.py
+++ b/pytest_jubilant/main.py
@@ -197,11 +197,11 @@ def pack_charm(root: Union[Path, str] = "./") -> _Result:
         if (meta_yaml := Path(root) / meta_name).exists():
             logging.debug(f"found metadata file: {meta_yaml}")
             meta = yaml.safe_load(meta_yaml.read_text())
-            if "resources" in meta.keys():
+            if meta_resources := meta.get("resources"):
                 try:
                     resources = {
                         resource: res_meta["upstream-source"]
-                        for resource, res_meta in meta["resources"].items()
+                        for resource, res_meta in meta_resources.items()
                     }
                 except KeyError:
                     logging.exception(


### PR DESCRIPTION
Walrus operator still throws a `KeyError`. 
Tested locally as a helper in the test code.