### PR TITLE
Without the absolute path, Juju can give error because is ambiguos.

### DIFF
--- a/pytest_jubilant/main.py
+++ b/pytest_jubilant/main.py
@@ -257,7 +257,7 @@ def pack(root: Union[Path, str] = "./", platform: Optional[str] = None) -> Path:
             "Pass a `platform` argument to control which charm you're getting instead."
         )
 
-    return Path(packed_charms[0])
+    return Path(packed_charms[0]).resolve()
 
 
 def get_resources(root: Union[Path, str] = "./") -> Optional[Dict[str, str]]:

--- a/tests/test_multiplatform_build.py
+++ b/tests/test_multiplatform_build.py
@@ -25,7 +25,7 @@ def test_pack_build_failure():
 
 def test_pack_single_platform():
     with mock_charmcraft_subprocess_call(["tempo.charm"]):
-        assert pack("./") == Path("tempo.charm")
+        assert pack("./") == Path("tempo.charm").resolve()
 
 
 def test_pack_multiplatform_unspecified():


### PR DESCRIPTION
E.g:

ERROR The charm or bundle "infra-backup-operator_ubuntu@24.04-amd64.charm" is ambiguous. To deploy a local charm or bundle, run `juju deploy ./infra-backup-operator_ubuntu@24.04-amd64.charm`. To deploy a charm or bundle from CharmHub, run `juju deploy ch:infra-backup-operator_ubuntu@24.04-amd64.charm`.

With absolute path solves this issue