### PR TITLE
chore: tox -e fmt (adjusts two blank lines, lets CI pass)

### DIFF
--- a/pytest_jubilant/main.py
+++ b/pytest_jubilant/main.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 """Main plugin module."""
+
 import dataclasses
 import logging
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 
-
 # do this on module import; doing it in a fixture would be already too late, because the patch
 # needs to be applied before the tempmodelfactory is invoked.
 os.environ["PYTESTING_PYTEST_JUBILANT"] = "1"


### PR DESCRIPTION
This PR is the result of running `tox -e fmt` on `main`. This adjusts two blank lines that would otherwise cause linting failures in CI right now.