### PR TITLE
refactor: avoid using pytest internals

### DIFF
--- a/pytest_jubilant/main.py
+++ b/pytest_jubilant/main.py
@@ -180,7 +180,8 @@ def temp_model_factory(request):
         factory.dump_all_logs(Path(dump_logs))
 
     if not (
-        request.config.getoption("--keep-models") or request.config.getoption("--no-teardown")
+        request.config.getoption("--keep-models")
+        or request.config.getoption("--no-teardown")
     ):
         # TODO: jubilant defaults to --force, but is that a good idea?
         factory.teardown(force=True)


### PR DESCRIPTION
This PR changes the implementation of `--no-teardown` implying `--keep-models` to check both flags explicitly before performing teardown. The current approach instead sets `--keep-models` internally if `--no-teardown` is passed by using Pytest's private `_opt2dest`.

Requesting review from @PietroPasotti to double check that this change makes sense, and ask if the existing tests validate this behaviour.