### PR TITLE
feat: export TempModelFactory class at package level

### DIFF
--- a/pytest_jubilant/__init__.py
+++ b/pytest_jubilant/__init__.py
@@ -4,6 +4,6 @@
 
 """Welcome to pytest-jubilant!"""
 
-from pytest_jubilant.main import pack, get_resources
+from pytest_jubilant.main import TempModelFactory, pack, get_resources
 
-__all__ = ["pack", "get_resources"]
+__all__ = ["TempModelFactory", "pack", "get_resources"]


### PR DESCRIPTION
We'd like to make the `main` module private to reduce the public API surface of the library. It's currently only [used by cos-coordinated-workers](https://github.com/canonical/cos-coordinated-workers/blob/e781d7b21a091492cfa7a7f66ed91cf5c57874be/tests/integration/test_service_mesh.py#L16) for `from pytest_jubilant.main import TempModelFactory`.

We want people to use `TempModelFactory` in their type annotations for the `temp_model_factory` fixture, so let's:
1. Expose it at the package level (this PR) and release a new minor version.
2. Make a PR to `cos-coordinated-workers` to use `from pytest_jubilant import TempModelFactory` instead.
4.  Rename `main` -> `_main` and release a new minor version -- technically a major breaking change, but doesn't affect any users, and no one is pinning their `pytest-jubilant` version right now anyway.