### PR TITLE
chore!: make version.py module private

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -19,7 +19,7 @@ jobs:
       run: |
         # strip the 'v' prefix
         TAG=$(git describe --tags --abbrev=0 | cut -c 2-)
-        echo "__version__ = \"$TAG\"" > pytest_jubilant/version.py
+        echo "__version__ = \"$TAG\"" > pytest_jubilant/_version.py
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/README.md
+++ b/README.md
@@ -227,4 +227,4 @@ git tag $new_tag -m "new fancy feature"
 git push origin head --tag
 ```
 
-Once the PR is merged, the release CI will kick in and put the tag in `pytest_jubilant.version.py`
+Once the PR is merged, the release CI will kick in and put the tag in `pytest_jubilant/_version.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ unit = [
 ]
 
 [tool.setuptools.dynamic]
-version = {attr = "pytest_jubilant.version.__version__"}
+version = {attr = "pytest_jubilant._version.__version__"}
 
 [project.urls]
 Homepage = "https://github.com/canonical/pytest-jubilant"
@@ -85,7 +85,4 @@ ignore = [
     "RUF003",  # FIXME: ambiguous character '❯'
     "S404",  # subprocess module, core functionality for this lib
     "S603",  # FIXME: construct charmcraft run command more statically
-]
-"pytest_jubilant/version.py" = [
-    "D205",  # FIXME: module docstring formatting
 ]

--- a/pytest_jubilant/_version.py
+++ b/pytest_jubilant/_version.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python3
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Version meta.
-Overridden by CI; do not modify.
+"""Version metadata.
+
+This entire file is overwritten in CI when publishing.
 """
 
 __version__ = 0.1  # OVERRIDDEN BY CI, DO NOT MODIFY


### PR DESCRIPTION
This PR makes the `version.py` module private. It is currently unused outside of our publishing CI. It seems wise to make it private to keep the library's public API intentional.

This PR does not make any other changes to the library's publishing and versioning CI.

Github searches:
- [pytest_jubilant.version](https://github.com/search?q=org%3Acanonical%20pytest_jubulant.version&type=code): no hits
- [from pytest_jubilant import](https://github.com/search?q=org%3Acanonical+from+pytest_jubilant+import&type=code): no results include `version`