### PR TITLE
fix: check e.stderr instead of e.args[1] for model exists error

### DIFF
--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -122,7 +122,10 @@ class TempModelFactory:
             # If --model is set (_check_models_unique is False), then the user wants collisions.
             # If the name is randomly generated, the chance of colliding with another
             # randomly generated model that wasn't torn down is tiny, but still present.
-            if "already exists on this k8s cluster" in e.args[1] and self._check_models_unique:
+            if (
+                "already exists on this k8s cluster" in (e.stderr or "")
+                and self._check_models_unique
+            ):
                 raise
 
         self._models[model_name] = juju


### PR DESCRIPTION
## Summary

- **Fix bug**: `CLIError` is a subclass of `subprocess.CalledProcessError`, constructed as `CLIError(returncode, cmd, stdout, stderr)`. Therefore `e.args[1]` is the command list (e.g. `['juju', 'add-model', ...]`), not the error message.
- The substring check `"already exists on this k8s cluster" in e.args[1]` against the command list would almost always evaluate to `False`, making the `_check_models_unique` guard effectively dead code.
- The fix checks `e.stderr` instead, which contains the actual error message from the Juju CLI. Uses `(e.stderr or "")` to handle the case where `stderr` is `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) but owned by me.