### PR TITLE
feat: output usage info based on whether --no-teardown was passed

### DIFF
--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -17,6 +17,9 @@ from typing import Callable
 import jubilant
 import pytest
 
+if typing.TYPE_CHECKING:
+    from _pytest.terminal import TerminalReporter
+
 # If the test failure occurs in the middle of a Juju operation, like processing an action,
 # then the logs for the operation in question might not be fully processed by Juju yet.
 # Testing with a mid-action failure several hundred times, 2 seconds seems like a reliable
@@ -25,6 +28,9 @@ import pytest
 # cases where the logs were missing the latest lines.
 _LOG_WAIT = 2.0  # Time to wait before processing logs if we need them.
 _LOG_LIMIT = 1000  # Number of log lines to dump to stderr on failure.
+
+# Unique per-session key to stash the model prefix for later output.
+_MODEL_PREFIX_KEY = pytest.StashKey[str]()
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -82,6 +88,30 @@ def pytest_configure(config: pytest.Config):
                 ", the model(s) identified by --model *will* be torn down!"
             )
         raise pytest.UsageError(msg)
+
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter,
+    exitstatus: pytest.ExitCode,
+    config: pytest.Config,
+):
+    """Print a usage hint after the test summary."""
+    prefix = config.stash.get(_MODEL_PREFIX_KEY, default=None)
+    if prefix is None:  # nothing that used temp_model_factory ran
+        return
+    terminalreporter.write_sep("-", "jubilant")
+    if config.getoption("--no-teardown"):
+        terminalreporter.write_line(
+            "Models were not torn down. To rerun tests on these models"
+            " and skip setup tests and model teardown, pass the following:"
+        )
+        terminalreporter.write_line(f"--no-setup --no-teardown --model {prefix}")
+    else:
+        terminalreporter.write_line(
+            "Models were torn down. To keep models available for subsequent"
+            " test runs or manual debugging, pass the following:"
+        )
+        terminalreporter.write_line("--no-teardown")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]):
@@ -169,9 +199,12 @@ class _TempModelFactory:
 
 
 @pytest.fixture(scope="session")
-def _session_prefix() -> str:  # pyright: ignore[reportUnusedFunction]
-    """Generate a prefix for the session."""
-    return f"jubilant-{secrets.token_hex(4)}"
+def _model_prefix(request: pytest.FixtureRequest) -> str:  # pyright: ignore[reportUnusedFunction]
+    """Generate a prefix for the session or use the user-provided one."""
+    user_prefix = typing.cast("str | None", request.config.getoption("--model"))
+    prefix = user_prefix or f"jubilant-{secrets.token_hex(4)}"
+    request.config.stash[_MODEL_PREFIX_KEY] = prefix
+    return prefix
 
 
 @pytest.fixture(scope="module")
@@ -196,15 +229,14 @@ def _sleep_once():  # pyright: ignore[reportUnusedFunction]
 def temp_model_factory(
     request: pytest.FixtureRequest,
     _sleep_once: Callable[[], None],
-    _session_prefix: str,
+    _model_prefix: str,
 ):
-    user_prefix = typing.cast("str | None", request.config.getoption("--model"))
     module_name = typing.cast("str", request.module.__name__)  # type: ignore
     module_part = module_name.rpartition(".")[-1].replace("_", "-")
     dump_logs = typing.cast("pathlib.Path | None", request.config.getoption("--dump-logs"))
     factory = _TempModelFactory(
-        model_prefix=f"{user_prefix or _session_prefix}-{module_part}",
-        allow_existing_model=bool(user_prefix),
+        model_prefix=f"{_model_prefix}-{module_part}",
+        allow_existing_model=bool(request.config.getoption("--model")),
         log_path=dump_logs,
         add_model=not typing.cast("bool", request.config.getoption("--no-setup")),
     )

--- a/tests/unit/test_terminal_summary.py
+++ b/tests/unit/test_terminal_summary.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+CONFTEST = (Path(__file__).parent / "conftest.py").read_text()
+TEST_FILE = """
+def test_something(juju):
+    pass
+"""
+
+
+def test_default_shows_teardown_hint(pytester: pytest.Pytester):
+    """When models are torn down (default), a hint to pass --no-teardown is shown."""
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(test_file=TEST_FILE)
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "*Models were torn down*",
+        "*--no-teardown*",
+    ])
+
+
+def test_default_no_teardown_shows_rerun_hint(pytester: pytest.Pytester):
+    """When --no-teardown is passed, a hint to rerun with the model prefix is shown."""
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(test_file=TEST_FILE)
+
+    result = pytester.runpytest("--no-teardown")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "*Models were not torn down*",
+        "--no-setup --no-teardown --model jubilant-deadbeef",
+    ])
+
+
+def test_explicit_model_shows_teardown_hint(pytester: pytest.Pytester):
+    """When --model is passed, a hint to pass --no-teardown is shown."""
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(test_file=TEST_FILE)
+
+    result = pytester.runpytest("--model", "my-model")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "*Models were torn down*",
+        "*--no-teardown*",
+    ])
+
+
+def test_explicit_model_with_no_teardown_shows_rerun_hint(pytester: pytest.Pytester):
+    """When --no-teardown is passed, a hint to rerun with the model prefix is shown."""
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(test_file=TEST_FILE)
+
+    result = pytester.runpytest("--model", "my-model", "--no-teardown")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "*Models were not torn down*",
+        "--no-setup --no-teardown --model my-model",
+    ])


### PR DESCRIPTION
This PR adds the additional output information discussed in #37. If we run without `--no-teardown`, we advise the user that models were torn down, and that they can avoid this with `--no-teardown`. If we run with `--no-teardown`, we advise the user that models weren't torn down, and that they can reuse the models by passing `--model` and the model prefix to pass.

<details>
<summary>Example test output for both cases</summary>

```
______________________________________ test_default_no_teardown_shows_rerun_hint _______________________________________
------------------------------------------------- Captured stdout call -------------------------------------------------
================================================= test session starts ==================================================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0
rootdir: /tmp/pytest-of-james.garner@canonical.com/pytest-137/test_default_no_teardown_shows_rerun_hint0
plugins: jubilant-0.1
collected 1 item

test_file.py .                                                                                                   [100%]

------------------------------------------------------- jubilant -------------------------------------------------------
Models were not torn down. To rerun tests on these models and skip setup tests and model teardown, pass the following:
--no-setup --no-teardown --model jubilant-deadbeef
================================================== 1 passed in 0.01s ===================================================
-------------------------------------------------- Captured log call ---------------------------------------------------
INFO     jubilant:_juju.py:228 cli: juju add-model --no-switch jubilant-deadbeef-test-file
_______________________________________ test_explicit_model_shows_teardown_hint ________________________________________
------------------------------------------------- Captured stdout call -------------------------------------------------
================================================= test session starts ==================================================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0
rootdir: /tmp/pytest-of-james.garner@canonical.com/pytest-137/test_explicit_model_shows_teardown_hint0
plugins: jubilant-0.1
collected 1 item

test_file.py .                                                                                                   [100%]

------------------------------------------------------- jubilant -------------------------------------------------------
Models were torn down. To keep models available for subsequent test runs or manual debugging, pass the following:
--no-teardown
```

</details>