### PR TITLE
feat!: namespace the CLI options, fixtures, and markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ And some cool stuff on top.
 ## `juju`
 This is a module(and model!)-scoped fixture that, by default, uses a temporary model and tears it down on context exit.
 
-See also the `--model`, `--no-setup`, and `--no-teardown` options below, which modify its behavior.
+See also the `--juju-model`, `--no-juju-setup`, and `--no-juju-teardown` options below, which modify its behavior.
 
 > [!TIP]
 > Use `jubilant.Juju` as the type annotation for the `juju` fixture in your tests for better linting and IDE autocompletions.
@@ -30,16 +30,16 @@ def test_deploy(juju: jubilant.Juju):
 This test will spin up a temporary model named `jubilant-<randomhex>-test-smoke`. It will be torn down when the module-scoped `juju` fixture context exits.
 
 
-## `temp_model_factory`
+## `juju_factory`
 This is a module-scoped fixture that manages temporary models for your test runs.
 It is what the `juju` fixture is using behind the scenes.
 
 Especially useful if you have test cases that require multiple models.
 
 > [!TIP]
-> Use `pytest_jubilant.TempModelFactory` as the type annotation for the `temp_model_factory` fixture in your tests for better linting and IDE autocompletions.
+> Use `pytest_jubilant.JujuFactory` as the type annotation for the `juju_factory` fixture in your tests for better linting and IDE autocompletions.
 >
-> Note that the exposed `TempModelFactory` type is just a protocol, and can't be used to directly create a temp model factory. Request the `temp_model_factory` fixture instead.
+> Note that the exposed `JujuFactory` type is just a protocol, and can't be used to directly create a juju factory. Request the `juju_factory` fixture instead.
 
 Usage:
 
@@ -53,8 +53,8 @@ import pytest_jubilant
 
 
 @pytest.fixture(scope="module")
-def istio(temp_model_factory: pytest_jubilant.TempModelFactory):
-    yield temp_model_factory.get_juju(suffix="istio")
+def istio(juju_factory: pytest_jubilant.JujuFactory):
+    yield juju_factory.get_juju(suffix="istio")
 
 
 def test_offer_consume_relate(juju: jubilant.Juju, istio: jubilant.Juju):
@@ -71,90 +71,90 @@ def test_offer_consume_relate(juju: jubilant.Juju, istio: jubilant.Juju):
 
 This test will spin up two temporary models, one called `jubilant-<randomhex>-test-cmr`, and one called `jubilant-<randomhex>-test-cmr-istio`. They'll be torn down when the module context exits.
 
-`pytest tests/integration --model my-prefix` will use `my-prefix` instead of `jubilant-<randomhex>`. The module names combined with the suffixes you defined in the fixtures will give all generated models predictable names. The tests will reuse the existing models (if found) or create new ones with those names.
+`pytest tests/integration --juju-model my-prefix` will use `my-prefix` instead of `jubilant-<randomhex>`. The module names combined with the suffixes you defined in the fixtures will give all generated models predictable names. The tests will reuse the existing models (if found) or create new ones with those names.
 
 
 # Pytest CLI options
 
-## `--model`
+## `--juju-model`
 By default, created Juju model names are prefixed with `jubilant-<randomhex>`, where `<randomhex>` is randomly generated each `pytest` run.
-Set `--model` on the commandline to use a fixed prefix instead.
+Set `--juju-model` on the commandline to use a fixed prefix instead.
 > [!WARNING]
-> Do note that models created with this prefix **will** be torn down at the end of the test run just like any other, so if you're targeting existing models you care about, don't forget the `--no-teardown` flag!.
+> Do note that models created with this prefix **will** be torn down at the end of the test run just like any other, so if you're targeting existing models you care about, don't forget the `--no-juju-teardown` flag!.
 
 Usage example, assuming a single model per module:
 
-    pytest tests/integration/test_foo.py::test_something --model my-prefix
+    pytest tests/integration/test_foo.py::test_something --juju-model my-prefix
     # runs the test on new 'my-prefix-test-foo' model and tears it down afterwards
 
     juju add-model my-prefix-test-foo
-    pytest tests/integration/test_foo.py::test_something --model my-prefix --no-teardown
+    pytest tests/integration/test_foo.py::test_something --juju-model my-prefix --no-juju-teardown
     # runs the tests on the existing 'my-prefix-test-foo' model and keeps it
     # note that we want to run the setup tests to deploy the charm(s) etc
 
-    pytest tests/integration/test_foo.py::test_something --model my-prefix --no-setup --no-teardown
+    pytest tests/integration/test_foo.py::test_something --juju-model my-prefix --no-juju-setup --no-juju-teardown
     # runs the tests on an existing 'my-prefix-test-foo' model, skipping setup tests, and keeps it
     # we might run this after the previous example which ran setup tests and didn't tear down
 
 
-## `--switch`
+## `--juju-switch`
 Switch to the (possibly randomly-named) model that is currently in scope, so you can keep an
 eye on the juju status as the tests progress.
 (Won't work well if you're running multiple test modules in parallel.)
-Only switches to models created by the `juju` fixture, not those created by `temp_model_factory`.
+Only switches to models created by the `juju` fixture, not those created by `juju_factory`.
 
 Usage:
 
-    pytest ./tests/integration -k test_something --switch
+    pytest ./tests/integration -k test_something --juju-switch
     # will switch you to the 'jubilant-<randomhex>-<module>' model as soon as it's created
 
-    pytest ./tests/integration -k test_something --model my-prefix --switch
+    pytest ./tests/integration -k test_something --juju-model my-prefix --juju-switch
     # will switch you to the 'my-prefix-<module>' model as soon as it's created
 
 
-## `--no-teardown`
-Skip all tests marked with `teardown` and skip destroying the models.
+## `--no-juju-teardown`
+Skip all tests marked with `juju_teardown` and skip destroying the models.
 Useful to inspect the state of a model after a (failed) test run.
 
 > [!WARNING]
 > The `--keep-models` flag used by `pytest-operator` is unsupported as of `pytest-jubilant` 2.0!
-> Be sure to use `--no-teardown` instead.
+> Be sure to use `--no-juju-teardown` instead.
 
 Usage:
-    pytest ./tests/integration --no-teardown
+    pytest ./tests/integration --no-juju-teardown
 
 
-## `--no-setup`
-Skip all tests marked with `setup`. Especially useful when re-running a test on an existing model which is already set-up, but not torn down.
+## `--no-juju-setup`
+Skip all tests marked with `juju_setup`. Especially useful when re-running a test on an existing model which is already set-up, but not torn down.
 See [this article](https://discourse.charmhub.io/t/14006) for the idea behind this workflow.
 Usage:
 
-    pytest ./tests/integration --no-teardown # make a note of the temporary model name
-    pytest ./tests/integration --model <temporary model prefix> --no-setup
+    pytest ./tests/integration --no-juju-teardown # check the last line of output for the model name
+    pytest ./tests/integration --no-juju-setup --juju-model <temporary model prefix>
 
 
-## `--dump-logs`
-Prior to tearing down all models owned by a temp_model_factory (i.e. prior to cleaning up a test module execution), dump the `juju debug-log --replay` for each model into a directory (default `"<CWD>/.logs"`). File naming scheme is:
+## `--juju-dump-logs`
+Prior to tearing down all models owned by a juju_factory (i.e. prior to cleaning up a test module execution), dump the `juju debug-log --replay` for each model into a directory (default `"<CWD>/.logs"`). File naming scheme is:
 
 `<module name>-<random bits>[-<suffix>]-jdl.txt`
 
 Usage:
 
-    pytest ./tests/integration ./integration/test_ingress.py --dump-logs=./debug_logs
+    pytest ./tests/integration ./integration/test_ingress.py --juju-dump-logs=./debug_logs
     # once the tests are done, you'll find the logs in
     # ./debug_logs/test-ingress-c372ef49-jdl.txt (random bits may vary).
 
-    pytest ./tests/integration ./integration/test_ingress.py --model foo --dump-logs=./debug_logs
+    pytest ./tests/integration ./integration/test_ingress.py --juju-model foo --juju-dump-logs=./debug_logs
     # once the tests are done, you'll find the logs in
     # ./debug_logs/foo-test-ingress-juju-debug.log
 
-    pytest ./tests/integration ./integration/test_ingress.py --dump-logs=""
+    pytest ./tests/integration ./integration/test_ingress.py --juju-dump-logs=""
     # no logs will be saved
 
 
 # Markers
 
-## `setup`
+## `juju_setup`
 
 Marker for tests that prepare (parts of) a model.
 
@@ -164,19 +164,19 @@ Usage:
 import pytest
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy(juju):
     juju.deploy("A")
     juju.deploy("B")
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_relate(juju):
     juju.integrate("A", "B")
 ```
 
 
-## `teardown`
+## `juju_teardown`
 Marker for tests that destroy (parts of) a model.
 
 Usage:
@@ -185,12 +185,12 @@ Usage:
 import pytest
 
 
-@pytest.mark.teardown
+@pytest.mark.juju_teardown
 def test_disintegrate(juju):
     juju.remove_relation("A", "B")
 
 
-@pytest.mark.teardown
+@pytest.mark.juju_teardown
 def test_destroy(juju):
     juju.remove_application("A")
     juju.remove_application("B")

--- a/pytest_jubilant/__init__.py
+++ b/pytest_jubilant/__init__.py
@@ -4,6 +4,6 @@
 
 """Welcome to pytest-jubilant!"""
 
-from pytest_jubilant._main import TempModelFactory
+from pytest_jubilant._main import JujuFactory
 
-__all__ = ["TempModelFactory"]
+__all__ = ["JujuFactory"]

--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -36,31 +36,31 @@ _MODEL_PREFIX_KEY = pytest.StashKey[str]()
 def pytest_addoption(parser: pytest.Parser):
     group = parser.getgroup("jubilant")
     group.addoption(
-        "--model",
+        "--juju-model",
         action="store",
         default=None,
         help="Prefix for Juju model names.",
     )
     group.addoption(
-        "--no-setup",
+        "--no-juju-setup",
         action="store_true",
         default=False,
-        help='Skip tests marked with "setup".',
+        help='Skip tests marked with "juju_setup".',
     )
     group.addoption(
-        "--no-teardown",
+        "--no-juju-teardown",
         action="store_true",
         default=False,
-        help='Skip tests marked with "teardown".',
+        help='Skip tests marked with "juju_teardown".',
     )
     group.addoption(
-        "--switch",
+        "--juju-switch",
         action="store_true",
         default=False,
         help="Switch to the temporary model that is currently being worked on.",
     )
     group.addoption(
-        "--dump-logs",
+        "--juju-dump-logs",
         action="store",
         nargs="?",
         const=pathlib.Path(".logs"),
@@ -72,20 +72,22 @@ def pytest_addoption(parser: pytest.Parser):
 
 
 def pytest_configure(config: pytest.Config):
-    config.addinivalue_line("markers", "setup: tests that setup some parts of the environment.")
     config.addinivalue_line(
-        "markers", "teardown: tests that tear down some parts of the environment."
+        "markers", "juju_setup: tests that setup some parts of the environment."
     )
-    if config.getoption("--no-setup") and not config.getoption("--model"):
+    config.addinivalue_line(
+        "markers", "juju_teardown: tests that tear down some parts of the environment."
+    )
+    if config.getoption("--no-juju-setup") and not config.getoption("--juju-model"):
         msg = (
-            "--no-setup cannot be specified without --model"
-            ", because --no-setup will skip model creation"
+            "--no-juju-setup cannot be specified without --juju-model"
+            ", because --no-juju-setup will skip model creation"
             ", and surely your tests need a model."
         )
-        if not config.getoption("--no-teardown"):
+        if not config.getoption("--no-juju-teardown"):
             msg += (
-                "\nNote that unless you specify --no-teardown"
-                ", the model(s) identified by --model *will* be torn down!"
+                "\nNote that unless you specify --no-juju-teardown"
+                ", the model(s) identified by --juju-model *will* be torn down!"
             )
         raise pytest.UsageError(msg)
 
@@ -97,42 +99,42 @@ def pytest_terminal_summary(
 ):
     """Print a usage hint after the test summary."""
     prefix = config.stash.get(_MODEL_PREFIX_KEY, default=None)
-    if prefix is None:  # nothing that used temp_model_factory ran
+    if prefix is None:  # nothing that used juju_factory ran
         return
     terminalreporter.write_sep("-", "jubilant")
-    if config.getoption("--no-teardown"):
+    if config.getoption("--no-juju-teardown"):
         terminalreporter.write_line(
             "Models were not torn down. To rerun tests on these models"
             " and skip setup tests and model teardown, pass the following:"
         )
-        terminalreporter.write_line(f"--no-setup --no-teardown --model {prefix}")
+        terminalreporter.write_line(f"--no-juju-setup --no-juju-teardown --juju-model {prefix}")
     else:
         terminalreporter.write_line(
             "Models were torn down. To keep models available for subsequent"
             " test runs or manual debugging, pass the following:"
         )
-        terminalreporter.write_line("--no-teardown")
+        terminalreporter.write_line("--no-juju-teardown")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]):
-    if config.getoption("--no-teardown"):
-        skipper = pytest.mark.skip(reason="--no-teardown provided.")
+    if config.getoption("--no-juju-teardown"):
+        skipper = pytest.mark.skip(reason="--no-juju-teardown provided.")
         for item in items:
-            if "teardown" in item.keywords:
+            if "juju_teardown" in item.keywords:
                 item.add_marker(skipper)
 
-    if config.getoption("--no-setup"):
-        skipper = pytest.mark.skip(reason="--no-setup provided.")
+    if config.getoption("--no-juju-setup"):
+        skipper = pytest.mark.skip(reason="--no-juju-setup provided.")
         for item in items:
-            if "setup" in item.keywords:
+            if "juju_setup" in item.keywords:
                 item.add_marker(skipper)
 
 
-class TempModelFactory(typing.Protocol):
+class JujuFactory(typing.Protocol):
     def get_juju(self, suffix: str) -> jubilant.Juju: ...
 
 
-class _TempModelFactory:
+class _JujuFactory:
     """Manages temporary models for testing."""
 
     def __init__(
@@ -152,7 +154,7 @@ class _TempModelFactory:
         model_name = f"{self._model_prefix}-{suffix}" if suffix else self._model_prefix
         if model_name in self._models:
             raise ValueError(
-                f"model {model_name} already registered on this temp_model factory. "
+                f"model {model_name} already registered on this juju_factory. "
                 "choose a different prefix."
             )
 
@@ -201,7 +203,7 @@ class _TempModelFactory:
 @pytest.fixture(scope="session")
 def _model_prefix(request: pytest.FixtureRequest) -> str:  # pyright: ignore[reportUnusedFunction]
     """Generate a prefix for the session or use the user-provided one."""
-    user_prefix = typing.cast("str | None", request.config.getoption("--model"))
+    user_prefix = typing.cast("str | None", request.config.getoption("--juju-model"))
     prefix = user_prefix or f"jubilant-{secrets.token_hex(4)}"
     request.config.stash[_MODEL_PREFIX_KEY] = prefix
     return prefix
@@ -226,19 +228,19 @@ def _sleep_once():  # pyright: ignore[reportUnusedFunction]
 
 
 @pytest.fixture(scope="module")
-def temp_model_factory(
+def juju_factory(
     request: pytest.FixtureRequest,
     _sleep_once: Callable[[], None],
     _model_prefix: str,
 ):
     module_name = typing.cast("str", request.module.__name__)  # type: ignore
     module_part = module_name.rpartition(".")[-1].replace("_", "-")
-    dump_logs = typing.cast("pathlib.Path | None", request.config.getoption("--dump-logs"))
-    factory = _TempModelFactory(
+    dump_logs = typing.cast("pathlib.Path | None", request.config.getoption("--juju-dump-logs"))
+    factory = _JujuFactory(
         model_prefix=f"{_model_prefix}-{module_part}",
-        allow_existing_model=bool(request.config.getoption("--model")),
+        allow_existing_model=bool(request.config.getoption("--juju-model")),
         log_path=dump_logs,
-        add_model=not typing.cast("bool", request.config.getoption("--no-setup")),
+        add_model=not typing.cast("bool", request.config.getoption("--no-juju-setup")),
     )
 
     yield factory
@@ -249,15 +251,15 @@ def temp_model_factory(
         _sleep_once()  # Wait for Juju to process logs or the latest lines might be missing
     factory._dump_all_logs(also_log_lines=also_log_lines)  # pyright: ignore[reportPrivateUsage]
 
-    if not request.config.getoption("--no-teardown"):
+    if not request.config.getoption("--no-juju-teardown"):
         # TODO: jubilant defaults to --force, but is that a good idea?
         factory._teardown(force=True)  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.fixture(scope="module")
-def juju(request: pytest.FixtureRequest, temp_model_factory: TempModelFactory):
-    juju = temp_model_factory.get_juju("")
-    if request.config.getoption("--switch"):
+def juju(request: pytest.FixtureRequest, juju_factory: JujuFactory):
+    juju = juju_factory.get_juju("")
+    if request.config.getoption("--juju-switch"):
         assert juju.model  # noqa: S101
         juju.cli("switch", juju.model, include_model=False)
     return juju

--- a/tests/integration/dump_logs_tests_fail.py
+++ b/tests/integration/dump_logs_tests_fail.py
@@ -14,9 +14,9 @@ if typing.TYPE_CHECKING:
 
 
 @pytest.fixture(scope="module")
-def models(temp_model_factory: pytest_jubilant.TempModelFactory):
-    foo = temp_model_factory.get_juju("foo1")
-    bar = temp_model_factory.get_juju("bar1")
+def models(juju_factory: pytest_jubilant.JujuFactory):
+    foo = juju_factory.get_juju("foo1")
+    bar = juju_factory.get_juju("bar1")
     yield foo, bar
 
 
@@ -27,7 +27,7 @@ def charm():
     yield charm_path
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy_and_then_fail(models: tuple[jubilant.Juju, jubilant.Juju], charm: pathlib.Path):
     foo, bar = models
     foo.deploy(charm)

--- a/tests/integration/dump_logs_tests_pass.py
+++ b/tests/integration/dump_logs_tests_pass.py
@@ -14,9 +14,9 @@ if typing.TYPE_CHECKING:
 
 
 @pytest.fixture(scope="module")
-def models(temp_model_factory: pytest_jubilant.TempModelFactory):
-    foo = temp_model_factory.get_juju("foo1")
-    bar = temp_model_factory.get_juju("bar1")
+def models(juju_factory: pytest_jubilant.JujuFactory):
+    foo = juju_factory.get_juju("foo1")
+    bar = juju_factory.get_juju("bar1")
     yield foo, bar
 
 
@@ -27,7 +27,7 @@ def charm():
     yield charm_path
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy_and_pass(models: tuple[jubilant.Juju, jubilant.Juju], charm: pathlib.Path):
     foo, bar = models
     foo.deploy(charm)

--- a/tests/integration/test_dump_logs.py
+++ b/tests/integration/test_dump_logs.py
@@ -19,7 +19,9 @@ def test_juju_debug_log_on_fail(pytester: pytest.Pytester, tmp_path: pathlib.Pat
     pytester.makepyfile(test_file1=test_file1, test_file2=test_file2)  # type: ignore
     custom_dir = tmp_path / "custom-logs"
 
-    result = pytester.runpytest_subprocess("--model", "model-t", "--dump-logs", str(custom_dir))
+    result = pytester.runpytest_subprocess(
+        "--juju-model", "model-t", "--juju-dump-logs", str(custom_dir)
+    )
 
     # We expect this session to fail.
     outcomes = result.parseoutcomes()
@@ -108,7 +110,9 @@ def test_juju_debug_log_on_pass(pytester: pytest.Pytester, tmp_path: pathlib.Pat
     pytester.makepyfile(test_file1=test_file1, test_file2=test_file2)  # type: ignore
     custom_dir = tmp_path / "custom-logs"
 
-    result = pytester.runpytest_subprocess("--model", "model-t", "--dump-logs", str(custom_dir))
+    result = pytester.runpytest_subprocess(
+        "--juju-model", "model-t", "--juju-dump-logs", str(custom_dir)
+    )
 
     # We expect this session to pass.
     outcomes = result.parseoutcomes()

--- a/tests/typecheck.py
+++ b/tests/typecheck.py
@@ -6,8 +6,8 @@ import pytest_jubilant
 import pytest_jubilant._main
 
 
-def needs_temp_model_factory(_: pytest_jubilant.TempModelFactory): ...
+def needs_juju_factory(_: pytest_jubilant.JujuFactory): ...
 
 
-def implements_temp_model_factory(t: pytest_jubilant._main._TempModelFactory):
-    needs_temp_model_factory(t)
+def implements_juju_factory(t: pytest_jubilant._main._JujuFactory):
+    needs_juju_factory(t)

--- a/tests/unit/cli_markers_tests.py
+++ b/tests/unit/cli_markers_tests.py
@@ -35,19 +35,19 @@ def _patch_model_operations():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _fixture(temp_model_factory: pytest_jubilant.TempModelFactory):
-    temp_model_factory.get_juju("autouse-module-scoped-fixture")
+def _fixture(juju_factory: pytest_jubilant.JujuFactory):
+    juju_factory.get_juju("autouse-module-scoped-fixture")
 
 
-@pytest.mark.setup
-def test_setup(temp_model_factory: pytest_jubilant.TempModelFactory):
-    temp_model_factory.get_juju("setup")
+@pytest.mark.juju_setup
+def test_setup(juju_factory: pytest_jubilant.JujuFactory):
+    juju_factory.get_juju("setup")
 
 
-def test_regular(temp_model_factory: pytest_jubilant.TempModelFactory):
-    temp_model_factory.get_juju("regular")
+def test_regular(juju_factory: pytest_jubilant.JujuFactory):
+    juju_factory.get_juju("regular")
 
 
-@pytest.mark.teardown
-def test_teardown(temp_model_factory: pytest_jubilant.TempModelFactory):
-    temp_model_factory.get_juju("teardown")
+@pytest.mark.juju_teardown
+def test_teardown(juju_factory: pytest_jubilant.JujuFactory):
+    juju_factory.get_juju("teardown")

--- a/tests/unit/cli_model_tests_already_exists.py
+++ b/tests/unit/cli_model_tests_already_exists.py
@@ -23,5 +23,5 @@ def _patch_add_model():
         yield
 
 
-def test_create_model(temp_model_factory: pytest_jubilant.TempModelFactory):
-    temp_model_factory.get_juju("my-fancy-model")
+def test_create_model(juju_factory: pytest_jubilant.JujuFactory):
+    juju_factory.get_juju("my-fancy-model")

--- a/tests/unit/cli_model_tests_other_cli_error.py
+++ b/tests/unit/cli_model_tests_other_cli_error.py
@@ -19,5 +19,5 @@ def _patch_add_model():
         yield
 
 
-def test_create_model(temp_model_factory: pytest_jubilant.TempModelFactory):
-    temp_model_factory.get_juju("my-fancy-model")
+def test_create_model(juju_factory: pytest_jubilant.JujuFactory):
+    juju_factory.get_juju("my-fancy-model")

--- a/tests/unit/test_cli_dump_logs.py
+++ b/tests/unit/test_cli_dump_logs.py
@@ -4,9 +4,9 @@ pytest_plugins = ["pytester"]
 
 CONFTEST = (Path(__file__).parent / "conftest.py").read_text()
 TEST_FILE = """
-def test_use_factory(temp_model_factory):
-    temp_model_factory.get_juju("foo")
-    temp_model_factory.get_juju("bar")
+def test_use_factory(juju_factory):
+    juju_factory.get_juju("foo")
+    juju_factory.get_juju("bar")
 """.strip()
 
 
@@ -24,7 +24,7 @@ def test_dump_logs_empty_path_disables(pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--dump-logs", "")
+    result = pytester.runpytest("--juju-dump-logs", "")
     result.assert_outcomes(passed=1)
 
     assert not (pytester.path / ".logs").exists()
@@ -34,7 +34,7 @@ def test_dump_logs_default_path(pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--dump-logs")
+    result = pytester.runpytest("--juju-dump-logs")
     result.assert_outcomes(passed=1)
 
     foo_log_path = pytester.path / ".logs" / "jubilant-deadbeef-test-file-foo-juju-debug.log"
@@ -50,7 +50,7 @@ def test_dump_logs_custom_path(pytester, tmp_path):
     pytester.makepyfile(test_file=TEST_FILE)
     custom_dir = tmp_path / "custom-logs"
 
-    result = pytester.runpytest("--dump-logs", str(custom_dir))
+    result = pytester.runpytest("--juju-dump-logs", str(custom_dir))
     result.assert_outcomes(passed=1)
 
     foo_log_path = custom_dir / "jubilant-deadbeef-test-file-foo-juju-debug.log"
@@ -65,14 +65,16 @@ def test_juju_debug_log_on_failure(pytester, tmp_path):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(
         test_file="""
-def test_fail(temp_model_factory):
-    temp_model_factory.get_juju("foo")
+def test_fail(juju_factory):
+    juju_factory.get_juju("foo")
     assert False
 """
     )
     custom_dir = tmp_path / "custom-logs"
 
-    result = pytester.runpytest_subprocess("--model", "model-t", "--dump-logs", str(custom_dir))
+    result = pytester.runpytest_subprocess(
+        "--juju-model", "model-t", "--juju-dump-logs", str(custom_dir)
+    )
 
     # We expect this session to fail.
     result.assert_outcomes(failed=1)

--- a/tests/unit/test_cli_markers.py
+++ b/tests/unit/test_cli_markers.py
@@ -40,7 +40,7 @@ def test_no_setup_ok(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--no-setup", "--model", "model-t")
+    result = pytester.runpytest("--no-juju-setup", "--juju-model", "model-t")
 
     result.assert_outcomes(passed=2, skipped=1)
     assert not (pytester.path / "added.txt").exists()
@@ -56,12 +56,12 @@ def test_no_setup_without_model_is_an_error(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--no-setup")
+    result = pytester.runpytest("--no-juju-setup")
 
     assert result.ret == 4  # Exit code for a pytest.UsageError
     result.stderr.re_match_lines([
-        ".*--no-setup cannot be specified without --model.*",
-        ".*unless you specify --no-teardown, the model.*",
+        ".*--no-juju-setup cannot be specified without --juju-model.*",
+        ".*unless you specify --no-juju-teardown, the model.*",
     ])
 
 
@@ -70,7 +70,7 @@ def test_no_teardown(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--no-teardown")
+    result = pytester.runpytest("--no-juju-teardown")
 
     result.assert_outcomes(passed=2, skipped=1)
     assert (pytester.path / "added.txt").read_text().splitlines() == [
@@ -89,7 +89,7 @@ def test_no_setup_and_no_teardown_ok(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--no-setup", "--no-teardown", "--model", "model-t")
+    result = pytester.runpytest("--no-juju-setup", "--no-juju-teardown", "--juju-model", "model-t")
 
     result.assert_outcomes(passed=1, skipped=2)
     assert not (pytester.path / "added.txt").exists()
@@ -101,10 +101,10 @@ def test_no_setup_and_no_teardown_without_model_is_an_error(pytester: pytest.Pyt
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--no-setup", "--no-teardown")
+    result = pytester.runpytest("--no-juju-setup", "--no-juju-teardown")
 
     assert result.ret == 4  # Exit code for a pytest.UsageError
-    result.stderr.re_match_lines([".*--no-setup cannot be specified without --model.*"])
+    result.stderr.re_match_lines([".*--no-juju-setup cannot be specified without --juju-model.*"])
 
 
 def test_m_setup(pytester: pytest.Pytester):
@@ -112,7 +112,7 @@ def test_m_setup(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("-m", "setup")
+    result = pytester.runpytest("-m", "juju_setup")
 
     result.assert_outcomes(passed=1, deselected=2)
     assert (pytester.path / "added.txt").read_text().splitlines() == [
@@ -130,7 +130,7 @@ def test_m_setup_with_no_teardown(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("-m", "setup", "--no-teardown")
+    result = pytester.runpytest("-m", "juju_setup", "--no-juju-teardown")
 
     result.assert_outcomes(passed=1, deselected=2)
     assert (pytester.path / "added.txt").read_text().splitlines() == [
@@ -145,7 +145,7 @@ def test_m_teardown(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("-m", "teardown")
+    result = pytester.runpytest("-m", "juju_teardown")
 
     result.assert_outcomes(passed=1, deselected=2)
     assert (pytester.path / "added.txt").read_text().splitlines() == [

--- a/tests/unit/test_cli_model.py
+++ b/tests/unit/test_cli_model.py
@@ -14,7 +14,7 @@ def test_explicit_model_allows_collisions(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_ALREADY_EXISTS)
 
-    result = pytester.runpytest("--model", "my-fancy-model")
+    result = pytester.runpytest("--juju-model", "my-fancy-model")
 
     result.assert_outcomes(passed=1)
 
@@ -43,7 +43,7 @@ def test_explicit_model_doesnt_prevent_other_errors(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_OTHER_CLI_ERROR)
 
-    result = pytester.runpytest("--model", "my-fancy-model")
+    result = pytester.runpytest("--juju-model", "my-fancy-model")
 
     result.assert_outcomes(failed=1)
     assert "ERROR something else" in result.stdout.str()

--- a/tests/unit/test_multimodel.py
+++ b/tests/unit/test_multimodel.py
@@ -7,13 +7,13 @@ import pytest_jubilant
 
 
 @pytest.fixture(scope="module")
-def istio(temp_model_factory: pytest_jubilant.TempModelFactory):
-    yield temp_model_factory.get_juju(suffix="istio")
+def istio(juju_factory: pytest_jubilant.JujuFactory):
+    yield juju_factory.get_juju(suffix="istio")
 
 
 @pytest.fixture(scope="module")
-def tempo(temp_model_factory: pytest_jubilant.TempModelFactory):
-    yield temp_model_factory.get_juju(suffix="tempo")
+def tempo(juju_factory: pytest_jubilant.JujuFactory):
+    yield juju_factory.get_juju(suffix="tempo")
 
 
 def test_multimodel(

--- a/tests/unit/test_terminal_summary.py
+++ b/tests/unit/test_terminal_summary.py
@@ -21,7 +21,7 @@ def test_default_shows_teardown_hint(pytester: pytest.Pytester):
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines([
         "*Models were torn down*",
-        "*--no-teardown*",
+        "*--no-juju-teardown*",
     ])
 
 
@@ -30,12 +30,12 @@ def test_default_no_teardown_shows_rerun_hint(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--no-teardown")
+    result = pytester.runpytest("--no-juju-teardown")
 
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines([
         "*Models were not torn down*",
-        "--no-setup --no-teardown --model jubilant-deadbeef",
+        "--no-juju-setup --no-juju-teardown --juju-model jubilant-deadbeef",
     ])
 
 
@@ -44,12 +44,12 @@ def test_explicit_model_shows_teardown_hint(pytester: pytest.Pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--model", "my-model")
+    result = pytester.runpytest("--juju-model", "my-model")
 
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines([
         "*Models were torn down*",
-        "*--no-teardown*",
+        "*--no-juju-teardown*",
     ])
 
 
@@ -58,10 +58,10 @@ def test_explicit_model_with_no_teardown_shows_rerun_hint(pytester: pytest.Pytes
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(test_file=TEST_FILE)
 
-    result = pytester.runpytest("--model", "my-model", "--no-teardown")
+    result = pytester.runpytest("--juju-model", "my-model", "--no-juju-teardown")
 
     result.assert_outcomes(passed=1)
     result.stdout.fnmatch_lines([
         "*Models were not torn down*",
-        "--no-setup --no-teardown --model my-model",
+        "--no-juju-setup --no-juju-teardown --juju-model my-model",
     ])


### PR DESCRIPTION
This PR updates the CLI options, fixtures, and markers to use the `juju` namespace as a prefix. This creates a consistent experience, avoids collision with names defined by other Pytest plugins, and makes it clearer to readers of integration tests where these names are defined.