### PR TITLE
test: fix markers from a bad merge

### DIFF
--- a/tests/integration/dump_logs_tests_fail.py
+++ b/tests/integration/dump_logs_tests_fail.py
@@ -20,7 +20,7 @@ def models(juju_factory: pytest_jubilant.JujuFactory):
     yield foo, bar
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy_and_then_fail(
     log_actions_charm: pathlib.Path, models: tuple[jubilant.Juju, jubilant.Juju]
 ):

--- a/tests/integration/dump_logs_tests_pass.py
+++ b/tests/integration/dump_logs_tests_pass.py
@@ -20,7 +20,7 @@ def models(juju_factory: pytest_jubilant.JujuFactory):
     yield foo, bar
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy_and_pass(
     log_actions_charm: pathlib.Path, models: tuple[jubilant.Juju, jubilant.Juju]
 ):


### PR DESCRIPTION
This PR corrects a couple of bad markers that slipped through due to insufficient scrutiny on my part. They're not actually exercised in these tests, so they didn't cause failures, but I think it's worth keeping them to model the kind of tests that we'd expect to use these markers.