### PR TITLE
chore: test with jubilant 1.8.0 and update unit tests accordingly

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,3 +78,5 @@ jobs:
             echo "${name^^}_CHARM_PATH=${{ github.workspace }}/${charm}" >> "$GITHUB_ENV"
           done
       - run: tox -e integration -- ${{ matrix.test }}
+        env:
+          TMPDIR: ${{ github.workspace }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.8"  # lower bound set by jubilant
 dependencies = [
-    "jubilant>=0.5.0",
+    "jubilant>=1,<2",
     "pytest>=8.3.5",
 ]
 classifiers = [

--- a/tests/integration/charms/log-actions/charmcraft.yaml
+++ b/tests/integration/charms/log-actions/charmcraft.yaml
@@ -20,6 +20,8 @@ actions:
   log:
     description: Make a lot of logging calls.
     additionalProperties: false
-  log-fail:
-    description: Make a lot of logging calls, then fail.
-    additionalProperties: false
+    params:
+      fail:
+        description: "Whether to fail the action after making the logging calls."
+        type: boolean
+        default: false

--- a/tests/integration/charms/log-actions/src/charm.py
+++ b/tests/integration/charms/log-actions/src/charm.py
@@ -17,16 +17,12 @@ class LogActionsCharm(ops.CharmBase):
         super().__init__(framework)
         framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         framework.observe(self.on["log"].action, self._on_log_action)
-        framework.observe(self.on["log_fail"].action, self._on_log_fail_action)
 
     def _on_log_action(self, event: ops.ActionEvent):
         for i in range(1, 10_000 + 1):
             logger.warning("Hello, it is I! '%s'", i)
-
-    def _on_log_fail_action(self, event: ops.ActionEvent):
-        for i in range(1, 10_000 + 1):
-            logger.warning("Hello, it is I! '%s'", i)
-        event.fail("Failing on purpose for tests.")
+        if event.params["fail"]:
+            event.fail("Failing on purpose for tests.")
 
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent):
         event.add_status(ops.ActiveStatus())

--- a/tests/integration/dump_logs_tests_fail.py
+++ b/tests/integration/dump_logs_tests_fail.py
@@ -29,4 +29,4 @@ def test_deploy_and_then_fail(
     bar.deploy(log_actions_charm, app="log")
     foo.wait(jubilant.all_active, timeout=900)
     bar.wait(jubilant.all_active)
-    foo.run("log/0", "log-fail")
+    foo.run("log/0", "log", {"fail": True})

--- a/tests/unit/test_multimodel.py
+++ b/tests/unit/test_multimodel.py
@@ -34,6 +34,7 @@ def test_multimodel(
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
         call(
             ["juju", "add-model", "--no-switch", "jubilant-deadbeef-test-multimodel-istio"],
@@ -41,6 +42,7 @@ def test_multimodel(
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
         call(
             ["juju", "add-model", "--no-switch", "jubilant-deadbeef-test-multimodel-tempo"],
@@ -48,6 +50,7 @@ def test_multimodel(
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
         call(
             ["juju", "deploy", "--model", "jubilant-deadbeef-test-multimodel", "something"],
@@ -55,6 +58,7 @@ def test_multimodel(
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
         call(
             [
@@ -68,5 +72,6 @@ def test_multimodel(
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
     ]

--- a/tests/unit/test_rootmodel.py
+++ b/tests/unit/test_rootmodel.py
@@ -12,6 +12,7 @@ def test_rootmodel(cli_mock, juju):
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
         call(
             ["juju", "deploy", "--model", "jubilant-deadbeef-test-rootmodel", "something"],
@@ -19,5 +20,6 @@ def test_rootmodel(cli_mock, juju):
             capture_output=True,
             encoding="utf-8",
             input=None,
+            timeout=None,
         ),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ description = Run integration tests
 dependency_groups = integration
 pass_env =
     *CHARM_PATH
+    TMPDIR
 commands =
     coverage run --source {toxinidir}/pytest_jubilant --branch -m \
         pytest --tb=native -vv --log-cli-level=DEBUG {toxinidir}/tests/integration {posargs}

--- a/uv.lock
+++ b/uv.lock
@@ -406,14 +406,14 @@ wheels = [
 
 [[package]]
 name = "jubilant"
-version = "0.5.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/87/f7b572051328839b2c0a058d53dc4a5f7af0897644da52a1ee8868490cbd/jubilant-0.5.0.tar.gz", hash = "sha256:02418b5116ffce02e2cc2c2275202baaad23eb02e253dbfba4ebecba00d3655f", size = 23670, upload-time = "2025-04-24T02:57:21.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/1b/32b5ab87c138066c80e34c8cd0f7d34760ce9d203d89ec88f979039e015d/jubilant-1.8.0.tar.gz", hash = "sha256:a7cea68299dca94fac3e121a8c8ed92021d20aa2f4461e16822abbcd134d0b8b", size = 33036, upload-time = "2026-03-30T07:42:23.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/9e/e760873c1dce7fd7b5ed46a4b376b88ace64b8a3b01c560125f3d3c468cf/jubilant-0.5.0-py3-none-any.whl", hash = "sha256:9f989a97b8fbbc21ed1c74289d8a269737a78407e4042d11d69c95dbe9356191", size = 22782, upload-time = "2025-04-24T02:57:20.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/6b/71ceb8de590d02eccf18cca60cb687838b12db0926a6a870c2d17a0d26b3/jubilant-1.8.0-py3-none-any.whl", hash = "sha256:e0495ee645de5f2df81d044a3b6e2827b5a6277de02c6d30935b9632bd868a98", size = 33929, upload-time = "2026-03-30T07:42:22.419Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ unit = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jubilant", specifier = ">=0.5.0" },
+    { name = "jubilant", specifier = ">=1,<2" },
     { name = "pytest", specifier = ">=8.3.5" },
 ]
 


### PR DESCRIPTION
This PR updates the `uv.lock` file to use the latest release of Jubilant (1.8.0), from the pre 1.0 version that was locked previously.

This is a manual PR because the unit tests needed to be updated (they assert on the `subprocess`  call made by Jubilant, which added `timeout=None` since they were originally written).

This PR also sets `TMPDIR`, which resolves #56. Without this, we now fail to deploy -- I guess Jubilant switched to deploying local charms from a temporary directory some time between these versions. To validate the `TMPDIR` change and fully resolve #56, this PR also switches to using a parametrized action, which would fail without the `TMPDIR` change because the params are written to the temporary directory.

Since we now assume a more recent version of Jubilant in our tests, this seems like a good opportunity to update the version we specify in `pyproject.toml` as well.