### PR TITLE
ci: Add TIOBE quality checks workflow

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -1,0 +1,49 @@
+name: TIOBE
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 7 * * 0'
+
+permissions: {}
+
+jobs:
+  TICS:
+    runs-on: [self-hosted, reactive, amd64, tiobe, noble]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - run: uv tool install tox --with tox-uv
+
+        # We could store the coverage report from the regular run, but this is cheap to do
+        # and keeps this isolated.
+      - name: Run unit tests and generate coverage report
+        run: |
+          tox -e unit
+          mkdir .report
+          uvx coverage xml -o .report/coverage.xml
+
+        # Note that these are dependencies for the tools that the TIOBE action will run,
+        # which is done in the global environment, rather than a venv, as we do with the
+        # unit tests.
+      - name: Install dependencies
+        run: |
+          uv export --no-emit-project --frozen --no-hashes > requirements.txt
+          pip install flake8 pylint -r requirements.txt --break-system-packages
+
+      - name: TICS GitHub Action
+        uses: tiobe/tics-github-action@3300ccc8de3c938cb83dc940ec4d07096c1bf185  # v3.9.1
+        with:
+          mode: qserver
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          project: pytest-jubilant
+          installTics: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 build
 dist
 .coverage
+.report
 .logs/
 /tests/.logs/
 .tmp/


### PR DESCRIPTION
Add a scheduled TIOBE/TICS workflow that runs weekly (and on demand) on Canonical's self-hosted TIOBE runners, mirroring canonical/jubilant.

Run the unit tests via tox and export a Cobertura coverage report to .report/coverage.xml for TICS to consume, then run the TICS GitHub action in qserver mode. Ignore the generated .report directory.