### PR TITLE
ci: add SBOM and secscan workflow

### DIFF
--- a/.github/.sbomber-manifest.yaml
+++ b/.github/.sbomber-manifest.yaml
@@ -1,0 +1,25 @@
+clients:
+  sbom:
+    service_url: https://sbom-request.canonical.com
+    department: charm_engineering
+    email: tony.meyer@canonical.com
+    team: charm_tech
+  secscan: {}
+
+artifacts:
+  - name: 'pytest-jubilant'
+    type: 'sdist'
+    compression: 'gz'
+    source: 'dist/pytest_jubilant-__VERSION__.tar.gz'
+    ssdlc_params:
+      name: 'pytest-jubilant'
+      version: ''
+      channel: 'stable'
+
+  - name: 'pytest-jubilant'
+    type: 'wheel'
+    source: 'dist/pytest_jubilant-__VERSION__-py3-none-any.whl'
+    ssdlc_params:
+      name: 'pytest-jubilant'
+      version: ''
+      channel: 'stable'

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -57,3 +57,7 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  secscan:
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/sbom-secscan.yaml

--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -1,0 +1,39 @@
+name: SBOM and secscan
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan:
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Set version from tag
+        run: |
+          TAG=$(git describe --tags --abbrev=0 | cut -c 2-)
+          echo "__version__ = \"${TAG}\"" > pytest_jubilant/_version.py
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Render manifest with built artifact version
+        run: |
+          version=$(ls dist/pytest_jubilant-*.tar.gz | sed -E 's|dist/pytest_jubilant-(.*)\.tar\.gz|\1|')
+          sed "s/__VERSION__/${version}/g" .github/.sbomber-manifest.yaml > "${RUNNER_TEMP}/sbomber-manifest.yaml"
+          cat "${RUNNER_TEMP}/sbomber-manifest.yaml"
+
+      - name: sbomber
+        uses: canonical/sbomber/.github/actions/run@cf7a76e810497ec932e8285b2c9d6b373d225e79  # main -- the sbomber-ref input below should match
+        with:
+          manifest: ${{ runner.temp }}/sbomber-manifest.yaml
+          artifact-name: secscan-report-upload
+          sbomber-ref: cf7a76e810497ec932e8285b2c9d6b373d225e79  # should match the ref in 'uses' above


### PR DESCRIPTION
Since this is a Charm Tech product, we should do the SSDLC expected secscan run.

- Adds `.github/.sbomber-manifest.yaml` covering sdist and wheel artifacts
- Adds `.github/workflows/sbom-secscan.yaml` modelled on `canonical/jubilant`'s equivalent workflow, using the same self-hosted runner and sbomber action
- Wires a `secscan` job into `build-and-publish.yaml` so it runs on every tag push alongside the PyPI publish

Like Jubilant, we re-build and use that for the submission, which is not ideal but avoids the race for the published version to be in PyPI. As discussed in the Jubilant PR, I think we should figure out a better solution in the future, but I don't think we need to do that this cycle.