### PR TITLE
feat: add support for cloud and controller in juju_factory fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ pytest tests/integration --juju-controller my-controller
 
 ### `--juju-cloud`
 
-Set the default Juju cloud (or cloud/region) to use when creating new models. This is equivalent to passing the cloud argument to `juju add-model`. It can be overridden by passing the `cloud` argument to `JujuFactory.get_model`. If neither is specified, Juju falls back to the currently active cloud.
+Set the default Juju cloud (or cloud/region) to use when creating new models. This is equivalent to passing the cloud argument to `juju add-model`. It can be overridden by passing the `cloud` argument to `JujuFactory.get_juju`. If neither is specified, Juju falls back to the currently active cloud.
 
 **Usage:**
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ This test will spin up two temporary models, one called `jubilant-<randomhex>-te
 
 `pytest tests/integration --juju-model hello` will use `hello` instead of `jubilant-<randomhex>`. The module names combined with the suffixes you defined in the fixtures will give all generated models predictable names. The tests will reuse the existing models (if found) or create new ones with those names.
 
+You can optionally pass `controller` and `cloud` to `juju_factory.get_juju` to 
+deploy individual models on specific controllers or clouds. This is useful for
+testing cross-model relations between different deployment types, such as machine
+and Kubernetes models on separate controllers.
+
 
 ## CLI options
 
@@ -167,6 +172,31 @@ pytest tests/integration/test_bar.py --juju-model hello --no-juju-teardown
 # Runs the test on the existing 'hello-test-bar' model and keeps it.
 # Note that we want to run the setup tests to deploy the charm(s) etc.
 # since this is a new model.
+```
+
+
+### `--juju-controller`
+
+Set the Juju controller to use when creating new models. This is equivalent to
+passing `--controller` to `juju add-model`.
+
+**Usage:**
+
+```shell
+pytest tests/integration --juju-controller my-controller
+```
+
+
+### `--juju-cloud`
+
+Set the Juju cloud (or cloud/region) to use when creating new models.
+This is equivalent to passing the cloud argument to `juju add-model`.
+
+**Usage:**
+
+```shell
+pytest tests/integration --juju-cloud localhost
+pytest tests/integration --juju-cloud aws/us-east-1
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,7 @@ This test will spin up two temporary models, one called `jubilant-<randomhex>-te
 
 `pytest tests/integration --juju-model hello` will use `hello` instead of `jubilant-<randomhex>`. The module names combined with the suffixes you defined in the fixtures will give all generated models predictable names. The tests will reuse the existing models (if found) or create new ones with those names.
 
-You can optionally pass `controller` and `cloud` to `juju_factory.get_juju` to 
-deploy individual models on specific controllers or clouds. This is useful for
-testing cross-model relations between different deployment types, such as machine
-and Kubernetes models on separate controllers.
+You can optionally pass `controller` and `cloud` to `juju_factory.get_juju` to deploy individual models on specific controllers or clouds. This is useful for testing cross-model relations between different deployment types, such as machine and Kubernetes models on separate controllers.
 
 
 ## CLI options
@@ -177,8 +174,7 @@ pytest tests/integration/test_bar.py --juju-model hello --no-juju-teardown
 
 ### `--juju-controller`
 
-Set the Juju controller to use when creating new models. This is equivalent to
-passing `--controller` to `juju add-model`.
+Set the default Juju controller to use when creating new models. This is equivalent to passing `--controller` to `juju add-model`. It can be overridden by passing the `controller` argument to `JujuFactory.get_juju`. If neither is specified, Juju falls back to the currently active controller.
 
 **Usage:**
 
@@ -189,8 +185,7 @@ pytest tests/integration --juju-controller my-controller
 
 ### `--juju-cloud`
 
-Set the Juju cloud (or cloud/region) to use when creating new models.
-This is equivalent to passing the cloud argument to `juju add-model`.
+Set the default Juju cloud (or cloud/region) to use when creating new models. This is equivalent to passing the cloud argument to `juju add-model`. It can be overridden by passing the `cloud` argument to `JujuFactory.get_model`. If neither is specified, Juju falls back to the currently active cloud.
 
 **Usage:**
 

--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -170,9 +170,9 @@ class JujuFactory(typing.Protocol):
     ) -> jubilant.Juju:
         """Return a `jubilant.Juju` for a model named `<prefix>-<suffix>`.
 
-         `<prefix>` is the factory's configured model-name prefix. If `suffix`
-         is empty, the model is named `<prefix>`. The same factory cannot
-         return two `Juju` instances for the same model name; raises
+        `<prefix>` is the factory's configured model-name prefix. If `suffix`
+        is empty, the model is named `<prefix>`. The same factory cannot
+        return two `Juju` instances for the same model name; raises
         `ValueError` if called twice with the same `suffix`.
 
         Pass `controller` and/or `cloud` to override the default Juju controller

--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -46,6 +46,18 @@ def pytest_addoption(parser: pytest.Parser):
         help="Prefix for Juju model names.",
     )
     group.addoption(
+        "--juju-controller",
+        action="store",
+        default=None,
+        help="The Juju controller to use for tests.",
+    )
+    group.addoption(
+        "--juju-cloud",
+        action="store",
+        default=None,
+        help="The Juju cloud to use for tests.",
+    )
+    group.addoption(
         "--no-juju-setup",
         action="store_true",
         default=False,
@@ -149,7 +161,13 @@ class JujuFactory(typing.Protocol):
     factory (see the ``juju_factory`` fixture).
     """
 
-    def get_juju(self, suffix: str) -> jubilant.Juju:
+    def get_juju(
+        self,
+        suffix: str,
+        *,
+        controller: str | None = None,
+        cloud: str | None = None,
+    ) -> jubilant.Juju:
         """Return a `jubilant.Juju` for a model named `<prefix>-<suffix>`.
 
         `<prefix>` is the factory's configured model-name prefix. If `suffix`
@@ -169,14 +187,24 @@ class _JujuFactory:
         allow_existing_model: bool = False,
         log_path: pathlib.Path | None = None,
         add_model: bool = False,
+        controller: str | None = None,
+        cloud: str | None = None,
     ):
         self._model_prefix = model_prefix
         self._models: dict[str, jubilant.Juju] = {}
         self._allow_existing_model = allow_existing_model
         self._log_path = log_path
         self._add_model = add_model
+        self._controller = controller
+        self._cloud = cloud
 
-    def get_juju(self, suffix: str) -> jubilant.Juju:
+    def get_juju(
+        self,
+        suffix: str,
+        *,
+        controller: str | None = None,
+        cloud: str | None = None,
+    ) -> jubilant.Juju:
         model_name = f"{self._model_prefix}-{suffix}" if suffix else self._model_prefix
         if model_name in self._models:
             raise ValueError(
@@ -184,10 +212,16 @@ class _JujuFactory:
                 "choose a different prefix."
             )
 
+        # Set controller and cloud for add_model, preferring args to factory defaults
+        juju_controller = controller if controller is not None else self._controller
+        juju_cloud = cloud if cloud is not None else self._cloud
+
+        # Include the controller prefix in the model_name for subsequent Juju calls.
+        model_name = f"{juju_controller}:{model_name}" if juju_controller else model_name
         juju = jubilant.Juju(model=model_name)
         if self._add_model:
             try:
-                juju.add_model(model_name)
+                juju.add_model(model=model_name, cloud=juju_cloud)
             except jubilant.CLIError as e:
                 # If --model is set (_allow_existing_model is True), then the user wants collisions.
                 # If the name is randomly generated, the chance of colliding with another
@@ -217,7 +251,8 @@ class _JujuFactory:
                 end_msg = f"--- end of `juju debug-log` for model {model} ---"
                 print(f"{msg}\n{last_n_lines}\n{end_msg}", file=sys.stderr, flush=True)
             if self._log_path:
-                jdl_path = self._log_path / (model + "-juju-debug.log")
+                model_filename = model.replace(":", "-")
+                jdl_path = self._log_path / (model_filename + "-juju-debug.log")
                 jdl_path.write_text(jdl)
                 logging.info("Wrote full `juju debug-log` for model %s to %s", model, jdl_path)
 
@@ -268,11 +303,15 @@ def juju_factory(
     module_name = typing.cast("str", request.module.__name__)  # type: ignore
     module_part = module_name.rpartition(".")[-1].replace("_", "-")
     dump_logs = typing.cast("pathlib.Path | None", request.config.getoption("--juju-dump-logs"))
+    controller_name = typing.cast("str | None", request.config.getoption("--juju-controller"))
+    cloud_name = typing.cast("str | None", request.config.getoption("--juju-cloud"))
     factory = _JujuFactory(
         model_prefix=f"{_model_prefix}-{module_part}",
         allow_existing_model=bool(request.config.getoption("--juju-model")),
         log_path=dump_logs,
         add_model=not typing.cast("bool", request.config.getoption("--no-juju-setup")),
+        controller=controller_name,
+        cloud=cloud_name,
     )
 
     yield factory

--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -170,15 +170,15 @@ class JujuFactory(typing.Protocol):
     ) -> jubilant.Juju:
         """Return a `jubilant.Juju` for a model named `<prefix>-<suffix>`.
 
-        `<prefix>` is the factory's configured model-name prefix. If `suffix`
-        is empty, the model is named `<prefix>`. The same factory cannot
-        return two `Juju` instances for the same model name; raises
-       `ValueError` if called twice with the same `suffix`.
-       
-       Pass `controller` and/or `cloud` to override the default Juju controller
-       and cloud on a per-model basis. These default to the values passed
-       on the command line (`--juju-controller`/`--juju-cloud`), with Juju falling
-       back to the active controller and cloud if they're not specified.
+         `<prefix>` is the factory's configured model-name prefix. If `suffix`
+         is empty, the model is named `<prefix>`. The same factory cannot
+         return two `Juju` instances for the same model name; raises
+        `ValueError` if called twice with the same `suffix`.
+
+        Pass `controller` and/or `cloud` to override the default Juju controller
+        and cloud on a per-model basis. These default to the values passed
+        on the command line (`--juju-controller`/`--juju-cloud`), with Juju falling
+        back to the active controller and cloud if they're not specified.
         """
         ...
 

--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -49,13 +49,13 @@ def pytest_addoption(parser: pytest.Parser):
         "--juju-controller",
         action="store",
         default=None,
-        help="The Juju controller to use for tests.",
+        help="The default Juju controller to use for tests.",
     )
     group.addoption(
         "--juju-cloud",
         action="store",
         default=None,
-        help="The Juju cloud to use for tests.",
+        help="The default Juju cloud to use for tests.",
     )
     group.addoption(
         "--no-juju-setup",
@@ -173,7 +173,12 @@ class JujuFactory(typing.Protocol):
         `<prefix>` is the factory's configured model-name prefix. If `suffix`
         is empty, the model is named `<prefix>`. The same factory cannot
         return two `Juju` instances for the same model name; raises
-        `ValueError` if called twice with the same `suffix`.
+       `ValueError` if called twice with the same `suffix`.
+       
+       Pass `controller` and/or `cloud` to override the default Juju controller
+       and cloud on a per-model basis. These default to the values passed
+       on the command line (`--juju-controller`/`--juju-cloud`), with Juju falling
+       back to the active controller and cloud if they're not specified.
         """
         ...
 

--- a/tests/unit/cli_cloud_tests.py
+++ b/tests/unit/cli_cloud_tests.py
@@ -1,0 +1,55 @@
+"""This file is executed via test_cli_cloud.py, it should not be run directly."""
+
+from unittest.mock import MagicMock, call
+
+import pytest_jubilant
+
+
+def test_cloud_is_passed_to_add_model(
+    cli_mock: MagicMock,
+    juju_factory: pytest_jubilant.JujuFactory,
+):
+    """If ``--juju-cloud`` is set, it is passed to ``juju add-model`` as a positional argument."""
+    cli_mock.reset_mock()
+    juju_factory.get_juju("my-model")
+    assert cli_mock.call_args_list == [
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                "jubilant-deadbeef-test-file-my-model",
+                "my-fancy-cloud",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+    ]
+
+
+def test_get_juju_overrides_cloud(
+    cli_mock: MagicMock,
+    juju_factory: pytest_jubilant.JujuFactory,
+):
+    """If JujuFactory is called with a cloud argument, it should override the CLI argument."""
+    cli_mock.reset_mock()
+    juju_factory.get_juju("override-model", cloud="override-cloud")
+    assert cli_mock.call_args_list == [
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                "jubilant-deadbeef-test-file-override-model",
+                "override-cloud",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+    ]

--- a/tests/unit/cli_controller_tests.py
+++ b/tests/unit/cli_controller_tests.py
@@ -1,0 +1,55 @@
+"""This file is executed via test_cli_controller.py, it should not be run directly."""
+
+from unittest.mock import MagicMock, call
+
+import pytest_jubilant
+
+
+def test_model_is_prefixed_with_controller(
+    cli_mock: MagicMock,
+    juju_factory: pytest_jubilant.JujuFactory,
+):
+    """If ``--juju-controller`` is set, it is used as the model prefix in ``juju add-model``."""
+    cli_mock.reset_mock()
+    juju = juju_factory.get_juju("my-model")
+    assert juju.model == "my-fancy-controller:jubilant-deadbeef-test-file-my-model"
+    assert cli_mock.call_args_list == [
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                "my-fancy-controller:jubilant-deadbeef-test-file-my-model",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+    ]
+
+
+def test_get_juju_overrides_controller(
+    cli_mock: MagicMock,
+    juju_factory: pytest_jubilant.JujuFactory,
+):
+    """If JujuFactory is called with a controller argument, it should override the CLI argument."""
+    cli_mock.reset_mock()
+    juju = juju_factory.get_juju("override-model", controller="override-controller")
+    assert juju.model == "override-controller:jubilant-deadbeef-test-file-override-model"
+    assert cli_mock.call_args_list == [
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                "override-controller:jubilant-deadbeef-test-file-override-model",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+    ]

--- a/tests/unit/test_cli_cloud.py
+++ b/tests/unit/test_cli_cloud.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+CONFTEST = (Path(__file__).parent / "conftest.py").read_text()
+TEST_FILE = (Path(__file__).parent / "cli_cloud_tests.py").read_text()
+
+
+def test_cli_cloud(pytester: pytest.Pytester):
+    """``--juju-cloud`` is used as juju argument, and can be overridden per get_juju() call."""
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(test_file=TEST_FILE)
+
+    result = pytester.runpytest("--juju-cloud", "my-fancy-cloud")
+
+    result.assert_outcomes(passed=2)

--- a/tests/unit/test_cli_controller.py
+++ b/tests/unit/test_cli_controller.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+CONFTEST = (Path(__file__).parent / "conftest.py").read_text()
+TEST_FILE = (Path(__file__).parent / "cli_controller_tests.py").read_text()
+
+
+def test_cli_controller(pytester: pytest.Pytester):
+    """``--juju-controller`` is used as model prefix, and can be overridden per get_juju() call."""
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(test_file=TEST_FILE)
+
+    result = pytester.runpytest("--juju-controller", "my-fancy-controller")
+
+    result.assert_outcomes(passed=2)

--- a/tests/unit/test_multicloud.py
+++ b/tests/unit/test_multicloud.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock, call
+
+import jubilant
+import pytest
+
+import pytest_jubilant
+
+K8S_CLOUD = "microk8s"
+MACHINE_CLOUD = "localhost"
+MODEL_NAME = "jubilant-deadbeef-test-multicloud"
+
+
+@pytest.fixture(scope="module")
+def juju_k8s(juju_factory: pytest_jubilant.JujuFactory):
+    """Juju instance for a model on the k8s cloud."""
+    yield juju_factory.get_juju(suffix="k8s", cloud=K8S_CLOUD)
+
+
+@pytest.fixture(scope="module")
+def juju_machine(juju_factory: pytest_jubilant.JujuFactory):
+    """Juju instance for a model on the machine cloud."""
+    yield juju_factory.get_juju(suffix="machine", cloud=MACHINE_CLOUD)
+
+
+def test_multicloud(
+    cli_mock: MagicMock,
+    juju_k8s: jubilant.Juju,
+    juju_machine: jubilant.Juju,
+):
+    """Test models on different clouds can be created and deployed to."""
+
+    juju_k8s.deploy("k8s-charm")
+    juju_machine.deploy("machine-charm")
+
+    assert cli_mock.call_args_list == [
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                f"{MODEL_NAME}-k8s",
+                K8S_CLOUD,
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                f"{MODEL_NAME}-machine",
+                MACHINE_CLOUD,
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+        call(
+            [
+                "juju",
+                "deploy",
+                "--model",
+                f"{MODEL_NAME}-k8s",
+                "k8s-charm",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+        call(
+            [
+                "juju",
+                "deploy",
+                "--model",
+                f"{MODEL_NAME}-machine",
+                "machine-charm",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+    ]

--- a/tests/unit/test_multicontroller.py
+++ b/tests/unit/test_multicontroller.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock, call
+
+import jubilant
+import pytest
+
+import pytest_jubilant
+
+K8S_CONTROLLER = "k8s-controller"
+MACHINE_CONTROLLER = "lxd-controller"
+MODEL_NAME = "jubilant-deadbeef-test-multicontroller"
+
+
+@pytest.fixture(scope="module")
+def juju_k8s(juju_factory: pytest_jubilant.JujuFactory):
+    """Juju instance for a model on the k8s controller."""
+    yield juju_factory.get_juju(suffix="k8s", controller=K8S_CONTROLLER)
+
+
+@pytest.fixture(scope="module")
+def juju_machine(juju_factory: pytest_jubilant.JujuFactory):
+    """Juju instance for a model on the machine controller."""
+    yield juju_factory.get_juju(suffix="machine", controller=MACHINE_CONTROLLER)
+
+
+def test_multicontroller(
+    cli_mock: MagicMock,
+    juju_k8s: jubilant.Juju,
+    juju_machine: jubilant.Juju,
+):
+    """Test models on different controllers are correctly prefixed."""
+
+    expected_k8s_model = f"{K8S_CONTROLLER}:{MODEL_NAME}-k8s"
+    assert juju_k8s.model == expected_k8s_model
+
+    expected_machine_model = f"{MACHINE_CONTROLLER}:{MODEL_NAME}-machine"
+    assert juju_machine.model == expected_machine_model
+
+    juju_k8s.deploy("k8s-charm")
+    juju_machine.deploy("machine-charm")
+
+    assert cli_mock.call_args_list == [
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                f"{K8S_CONTROLLER}:{MODEL_NAME}-k8s",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+        call(
+            [
+                "juju",
+                "add-model",
+                "--no-switch",
+                f"{MACHINE_CONTROLLER}:{MODEL_NAME}-machine",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+        call(
+            [
+                "juju",
+                "deploy",
+                "--model",
+                f"{K8S_CONTROLLER}:{MODEL_NAME}-k8s",
+                "k8s-charm",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+        call(
+            [
+                "juju",
+                "deploy",
+                "--model",
+                f"{MACHINE_CONTROLLER}:{MODEL_NAME}-machine",
+                "machine-charm",
+            ],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+            input=None,
+            timeout=None,
+        ),
+    ]


### PR DESCRIPTION
Description
----
This adds support for passing controller or cloud name given those arguments are supported by `jubilant`. 
This extends the capabilities of the `juju_factory` so anyone can tests CMR between different type of charms (k8s vs machine). 

Implementation
----
This PR:
1. Allow passing `juju_controller` and/or `juju_clouds` defaults to None so its backward compatible
2. If `juju_controller` is provided, it will prefix the `model_name` as suggested in Jubilant documentation

Resolved issues
----
Resolves #66 

Tests
---- 
I added unit tests for testing `juju_factory` with both k8s and machine controllers/clouds. The tests passed locally. 

I took the liberty to open an issue and propose the enhancement but if any of those is outside the scope of what `pytest-jubilant` should do please feel free to let me know!