### PR TITLE
test: adopt -Werror in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ pytest-jubilant = "pytest_jubilant._main"
 
 [tool.pytest.ini_options]
 # Promote warnings (deprecations, resource-cleanup leaks, etc.) to errors so
-# they surface in CI rather than going unnoticed. Part of the Charm Tech
-# -Werror rollout (roadmap 26.10/w-error).
+# they surface in CI rather than going unnoticed.
 filterwarnings = [
     "error",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ Issues = "https://github.com/canonical/pytest-jubilant/issues"
 [project.entry-points.pytest11]
 pytest-jubilant = "pytest_jubilant._main"
 
+[tool.pytest.ini_options]
+# Promote warnings (deprecations, resource-cleanup leaks, etc.) to errors so
+# they surface in CI rather than going unnoticed. Part of the Charm Tech
+# -Werror rollout (roadmap 26.10/w-error).
+filterwarnings = [
+    "error",
+]
+
 [tool.ruff]
 line-length = 99
 target-version = "py38"


### PR DESCRIPTION
This PR changes pytest to treat warnings as errors when running the unit tests. Everything already passes, so this is only the config change; nothing else is needed.