### PR TITLE
ci: attest build provenance for released artifacts

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+      uses: actions/attest-build-provenance@v3.2
       with:
         subject-path: 'dist/*'
     - name: Store the distribution packages

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -9,6 +9,11 @@ jobs:
     name: Build distribution 📦
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
     steps:
     - uses: actions/checkout@v6
       with:
@@ -30,6 +35,10 @@ jobs:
         --user
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+      with:
+        subject-path: 'dist/*'
     - name: Store the distribution packages
       uses: actions/upload-artifact@v7
       with:


### PR DESCRIPTION
This brings pytest-jubilant into alignment with most of the other Charm Tech repos. PyPI does have build attestation, but there is value in having attestation as part of the core build process.