### PR TITLE
fix: correct the attest-build-provenance action tag

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@v3.2
+      uses: actions/attest-build-provenance@v4.1.0
       with:
         subject-path: 'dist/*'
     - name: Store the distribution packages


### PR DESCRIPTION
3.2 should have been v3.2.0. Bump to the latest, v4.1.0.