### PR TITLE
feat: add pytest-jubilant logger and drop printing 1000 lines on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ pytest tests/integration -k test_something --juju-model hello --juju-switch
 
 When all the tests in a module have completed, but prior to tearing down the models owned by a [juju_factory](#juju_factory), dump the `juju debug-log` for each managed model into the specified directory.
 
-- By default, logs aren't dumped, and `juju debug-log` is only executed if tests failed, so that the last log lines can be sent to stderr.
+- By default, `juju debug-log` is not run, and logs aren't dumped.
 - If `--juju-dump-logs` is passed, logs are dumped to `<CWD>/.logs/`.
 - If `--juju-dump-logs <target dir>` is passed, logs are dumped to `<target dir>/`.
 

--- a/pytest_jubilant/_main.py
+++ b/pytest_jubilant/_main.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 import pathlib
 import secrets
-import sys
 import time
 import typing
 
@@ -21,6 +20,8 @@ if typing.TYPE_CHECKING:
 
     from _pytest.terminal import TerminalReporter
 
+logger = logging.getLogger("pytest-jubilant")
+
 # If the test failure occurs in the middle of a Juju operation, like processing an action,
 # then the logs for the operation in question might not be fully processed by Juju yet.
 # Testing with a mid-action failure several hundred times, 2 seconds seems like a reliable
@@ -28,7 +29,6 @@ if typing.TYPE_CHECKING:
 # on factors like system load). Several hundred tests with a 1 second wait had a handful of
 # cases where the logs were missing the latest lines.
 _LOG_WAIT = 2.0  # Time to wait before processing logs if we need them.
-_LOG_LIMIT = 1000  # Number of log lines to dump to stderr on failure.
 
 # Unique per-session key to stash the model prefix for later output.
 _MODEL_PREFIX_KEY = pytest.StashKey[str]()
@@ -245,27 +245,17 @@ class _JujuFactory:
         self._models[model_name] = juju
         return juju
 
-    def _dump_all_logs(self, *, also_log_lines: int = 0):
-        if not (also_log_lines or self._log_path):
+    def _dump_all_logs(self):
+        if not self._log_path:
             return
-        if self._log_path:
-            self._log_path.mkdir(parents=True, exist_ok=True)
+
+        self._log_path.mkdir(parents=True, exist_ok=True)
         for model, juju in self._models.items():
-            jdl = juju.debug_log(limit=0 if self._log_path else also_log_lines)
-            if also_log_lines:
-                msg = f"Logging last {also_log_lines} lines of `juju debug-log` for model {model}:"
-                last_n_lines = (
-                    "\n".join(jdl.rsplit("\n", also_log_lines)[-also_log_lines:])
-                    if self._log_path
-                    else jdl
-                )
-                end_msg = f"--- end of `juju debug-log` for model {model} ---"
-                print(f"{msg}\n{last_n_lines}\n{end_msg}", file=sys.stderr, flush=True)
-            if self._log_path:
-                model_filename = model.replace(":", "-")
-                jdl_path = self._log_path / (model_filename + "-juju-debug.log")
-                jdl_path.write_text(jdl)
-                logging.info("Wrote full `juju debug-log` for model %s to %s", model, jdl_path)
+            jdl = juju.debug_log()
+            model_filename = model.replace(":", "-")
+            jdl_path = self._log_path / (model_filename + "-juju-debug.log")
+            jdl_path.write_text(jdl)
+            logger.info("Wrote full `juju debug-log` for model %s to %s", model, jdl_path)
 
     def _teardown(self, force: bool = False):
         for model, juju in self._models.items():
@@ -328,10 +318,9 @@ def juju_factory(
     yield factory
 
     # BEFORE tearing down the models, dump any and all juju debug-logs
-    also_log_lines = _LOG_LIMIT if request.session.testsfailed else 0
-    if also_log_lines or dump_logs:
+    if dump_logs:
         _sleep_once()  # Wait for Juju to process logs or the latest lines might be missing
-    factory._dump_all_logs(also_log_lines=also_log_lines)  # pyright: ignore[reportPrivateUsage]
+    factory._dump_all_logs()  # pyright: ignore[reportPrivateUsage]
 
     if not request.config.getoption("--no-juju-teardown"):
         # Match jubilant's temp_model fixture: --force so failed tests with apps

--- a/tests/integration/test_dump_logs.py
+++ b/tests/integration/test_dump_logs.py
@@ -33,29 +33,6 @@ def test_juju_debug_log_on_fail(pytester: pytest.Pytester, tmp_path: pathlib.Pat
     assert outcomes.get("failed") == 2
 
     # test_file1
-    # We emit the last 1000 lines of `juju debug-log` for each model if tests fail.
-    # Model 'model-t-test-file1-foo1': emits 10k lines of logs in an action and then fails.
-    foo1_msg = "Logging last 1000 lines of `juju debug-log` for model model-t-test-file1-foo1:"
-    foo1_lines = result.stdout.get_lines_after(f"*{foo1_msg}*")  # Match with fnmatch.
-    foo1_end = _index_contains(
-        foo1_lines, "--- end of `juju debug-log` for model model-t-test-file1-foo1 ---"
-    )
-    assert foo1_end == 1000
-    foo1_last_lines = foo1_lines[:foo1_end]
-    assert _in_line("Hello, it is I! '10000'", foo1_last_lines)
-    assert not _in_line("Hello, it is I! '1'", foo1_last_lines)  # We only log the last 1k lines.
-
-    # Model 'model-t-test-file1-bar1': cleaned up when the tests exit after the action failed.
-    bar1_msg = "Logging last 1000 lines of `juju debug-log` for model model-t-test-file1-bar1:"
-    bar1_lines = result.stdout.get_lines_after(f"*{bar1_msg}*")  # Match with fnmatch.
-    bar1_end = _index_contains(
-        bar1_lines, "--- end of `juju debug-log` for model model-t-test-file1-bar1 ---"
-    )
-    assert bar1_end > 1
-    assert bar1_end < 1000  # We didn't run the log action so there aren't that many log lines.
-    bar1_last_lines = bar1_lines[:bar1_end]
-    assert not _in_line("Hello, it is I!", bar1_last_lines)  # We don't run the log action for bar.
-
     # The full logs are still written on failure with --dump-logs.
     foo1_log_path = custom_dir / "model-t-test-file1-foo1-juju-debug.log"
     assert foo1_log_path.exists()
@@ -70,29 +47,6 @@ def test_juju_debug_log_on_fail(pytester: pytest.Pytester, tmp_path: pathlib.Pat
     assert not _in_line("Hello, it is I!", bar1_full_log_lines)
 
     # test_file2
-    # We emit the last 1000 lines of `juju debug-log` for each model if tests fail.
-    # Model 'model-t-test-file2-foo2': emits 10k lines of logs in an action and then fails.
-    foo2_msg = "Logging last 1000 lines of `juju debug-log` for model model-t-test-file2-foo2:"
-    foo2_lines = result.stdout.get_lines_after(f"*{foo2_msg}*")  # Match with fnmatch.
-    foo2_end = _index_contains(
-        foo2_lines, "--- end of `juju debug-log` for model model-t-test-file2-foo2 ---"
-    )
-    assert foo2_end == 1000
-    foo2_last_lines = foo2_lines[:foo2_end]
-    assert _in_line("Hello, it is I! '10000'", foo2_last_lines)
-    assert not _in_line("Hello, it is I! '1'", foo2_last_lines)  # We only log the last 1k lines.
-
-    # Model 'model-t-test-file2-bar2': cleaned up when the tests exit after the action failed.
-    bar2_msg = "Logging last 1000 lines of `juju debug-log` for model model-t-test-file2-bar2:"
-    bar2_lines = result.stdout.get_lines_after(f"*{bar2_msg}*")  # Match with fnmatch.
-    bar2_end = _index_contains(
-        bar2_lines, "--- end of `juju debug-log` for model model-t-test-file2-bar2 ---"
-    )
-    assert bar2_end > 1
-    assert bar2_end < 1000  # We didn't run the log action so there aren't that many log lines.
-    bar2_last_lines = bar2_lines[:bar2_end]
-    assert not _in_line("Hello, it is I!", bar2_last_lines)  # We don't run the log action for bar.
-
     # The full logs are still written on failure with --dump-logs.
     foo2_log_path = custom_dir / "model-t-test-file2-foo2-juju-debug.log"
     assert foo2_log_path.exists()
@@ -125,11 +79,6 @@ def test_juju_debug_log_on_pass(pytester: pytest.Pytester, tmp_path: pathlib.Pat
     assert outcomes.get("passed") == 2
     assert "failed" not in outcomes
 
-    # Debug log should NOT be emitted to stderr when tests pass.
-    stdout = result.stdout.str()
-    assert "Logging last 1000 lines of `juju debug-log` for model" not in stdout
-    assert "--- end of `juju debug-log`" not in stdout
-
     # The full logs are still written with --dump-logs even on success.
     foo1_log_path = custom_dir / "model-t-test-file1-foo1-juju-debug.log"
     assert foo1_log_path.exists()
@@ -157,13 +106,6 @@ def test_juju_debug_log_on_pass(pytester: pytest.Pytester, tmp_path: pathlib.Pat
     assert len(bar2_full_log_lines) > 10_000  # log action logs 10k times
     assert _in_line("Hello, it is I! '1'", bar2_full_log_lines)
     assert _in_line("Hello, it is I! '10000'", bar2_full_log_lines)
-
-
-def _index_contains(lines: Iterable[str], target: str) -> int:
-    for i, line in enumerate(lines):
-        if target in line:
-            return i
-    raise ValueError(f"No match for {target!r} in {lines}")
 
 
 def _in_line(target: str, lines: Iterable[str]) -> bool:

--- a/tests/unit/test_cli_dump_logs.py
+++ b/tests/unit/test_cli_dump_logs.py
@@ -79,12 +79,7 @@ def test_fail(juju_factory):
     # We expect this session to fail.
     result.assert_outcomes(failed=1)
 
-    # We emit the last 1000 lines of `juju debug-log` for each model if tests fail.
-    foo_msg = "Logging last 1000 lines of `juju debug-log` for model model-t-test-file-foo:"
-    foo_lines = result.stdout.get_lines_after(f"*{foo_msg}*")  # Match with fnmatch.
-    assert foo_lines[0] == "stdout patched by conftest.py"  # Mocked call to Juju CLI.
-    assert foo_lines[1] == "--- end of `juju debug-log` for model model-t-test-file-foo ---"
-
     # The full logs are still written on failure with --dump-logs.
     foo_log_path = custom_dir / "model-t-test-file-foo-juju-debug.log"
     assert foo_log_path.exists()
+

--- a/tests/unit/test_cli_dump_logs.py
+++ b/tests/unit/test_cli_dump_logs.py
@@ -82,4 +82,3 @@ def test_fail(juju_factory):
     # The full logs are still written on failure with --dump-logs.
     foo_log_path = custom_dir / "model-t-test-file-foo-juju-debug.log"
     assert foo_log_path.exists()
-


### PR DESCRIPTION
This PR removes printing the last 1000 lines of juju debug-log to stderr when a test fails.

This is a follow up from [this discussion](https://github.com/canonical/pytest-jubilant/pull/97#issuecomment-4920654159). I asked a couple Charmers and there is no push-back so far (end of Friday 10/07). I think we are safe to remove it.

I also update the tests, create a `pytest-jubilant` logger, and update README.md on the default behavior of `--juju-dump-logs`.

Fixes https://github.com/canonical/pytest-jubilant/issues/74.