### PR TITLE
ci: fix zizmor ref-version-mismatch in upload-sarif pin

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -30,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
The upload-sarif step was pinned to hash 8aad20d1 but commented # v4, which points to a different commit. That hash is tag v4.36.2, so update the comment to match the pinned version.