### PR TITLE
chore: bump pytest from 8.3.5 to 9.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10"  # lower bound set by jubilant
 dependencies = [
     "jubilant>=1,<2",
-    "pytest>=8.3.5",
+    "pytest>=9.1.1",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -26,11 +26,11 @@ lint = [
 ]
 unit = [
     "coverage[toml]~=7.6",
-    "pytest~=8.3",
+    "pytest~=9.1",
 ]
 integration = [
     "coverage[toml]~=7.6",
-    "pytest~=8.3",
+    "pytest~=9.1",
     "ops>=2,<4",
 ]
 # Tool versions consumed by CI workflows. Pinned here so pyproject.toml /

--- a/uv.lock
+++ b/uv.lock
@@ -338,6 +338,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pylint"
 version = "4.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -383,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -391,11 +400,12 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -435,14 +445,14 @@ zizmor = [
 [package.metadata]
 requires-dist = [
     { name = "jubilant", specifier = ">=1,<2" },
-    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", specifier = ">=9.1.1" },
 ]
 
 [package.metadata.requires-dev]
 integration = [
     { name = "coverage", extras = ["toml"], specifier = "~=7.6" },
     { name = "ops", specifier = ">=2,<4" },
-    { name = "pytest", specifier = "~=8.3" },
+    { name = "pytest", specifier = "~=9.1" },
 ]
 lint = [
     { name = "pyright", specifier = "~=1.1" },
@@ -458,7 +468,7 @@ tox = [
 ]
 unit = [
     { name = "coverage", extras = ["toml"], specifier = "~=7.6" },
-    { name = "pytest", specifier = "~=8.3" },
+    { name = "pytest", specifier = "~=9.1" },
 ]
 zizmor = [{ name = "zizmor", specifier = "~=1.23" }]
 


### PR DESCRIPTION
Unlocked by the move to require Python 3.10+. Resolves a security issue, which theoretically could impact our use, although it would require a chain to exploit.